### PR TITLE
Use UPnP Load instead of discovery if endpoint is specified

### DIFF
--- a/ipsource.go
+++ b/ipsource.go
@@ -194,6 +194,10 @@ var defaultHTTPIPServices = []string{
 
 // UPnP gets the IP address from UPnP device.
 type UPnP struct {
+	// The UPnP endpoint to query. If empty, the default UPnP
+	// discovery will be used. 
+	Endpoint string `json:"endpoints,omitempty"`
+
 	logger *zap.Logger
 }
 
@@ -206,6 +210,12 @@ func (UPnP) CaddyModule() caddy.ModuleInfo {
 }
 
 func (u *UPnP) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
+	d.Next() // skip directive name
+	if d.NextArg() {
+		u.Endpoint = d.Val()
+	} else {
+		u.Endpoint = ""
+	}
 	return nil
 }
 
@@ -220,7 +230,14 @@ func (u *UPnP) Provision(ctx caddy.Context) error {
 // we can't really choose whether we're looking for IPv4 or IPv6
 // with UPnP, we just get what we get.
 func (u UPnP) GetIPs(ctx context.Context, _ IPVersions) ([]net.IP, error) {
-	d, err := upnp.DiscoverCtx(ctx)
+	var d *upnp.IGD
+	var err error
+	if u.Endpoint != "" {
+		d, err = upnp.Load(u.Endpoint)
+	} else {
+		d, err = upnp.DiscoverCtx(ctx)
+	}
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
To speed up external IP querying with UPnP, `upnp.Load(location)` with a static UPnP location can be used instead of the default UPnP discovery. The location can be specified in the Caddyfile as `ip_source upnp http://192.168.1.1/...`. If this endpoint is not specified, then the standard UPnP discovery is used.

When using `upnp.Load(location)`, only HTTP messages are send to the network gateway. Therefore, if Caddy is used inside a docker container, Caddy doesn't need access direct access to the host network (`--network host`).

The location for the Caddyfile can be identified by using `upnpc -s` (`apt install miniupnpc`).